### PR TITLE
Watchdog plus more

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ A heartbeat signal will always be transmitted and **cannot be disabled**, even w
 
 > **Note:** If the heartbeat resets to 1 before reaching 255, this indicates that the MKR WAN 1310 has been restarted.
 
-### Downlink Command Structure
+## Downlink Command Structure
 
 The device supports several LoRaWAN downlink commands for remote configuration and control. Downlink messages follow a simple command-based structure, where the **first byte indicates the command type**, and the **subsequent bytes contain any associated parameters**.
 
@@ -128,7 +128,7 @@ Each command is processed immediately after uplink transmission or upon receivin
 
 ---
 
-#### **Command 0x01: Change LoRaWAN Transmit Period**
+### **Command 0x01: Change LoRaWAN Transmit Period**
 
 **Purpose:** Updates how often the device sends uplink packets over LoRaWAN.  
 **Structure:**  
@@ -148,7 +148,7 @@ To set a 10-minute (600-second) transmit period:
 
 ---
 
-#### **Command 0x02: Force Sample**
+### **Command 0x02: Force Sample**
 
 **Purpose:** Triggers an immediate sample on the adapter and sends a LoRaWAN uplink with the latest data.  
 **Structure:**  
@@ -163,7 +163,7 @@ To set a 10-minute (600-second) transmit period:
 >NOTE: the firmware takes 15 seconds since it takes 15 seconds for the exosonde to fill the registers with the new values.
 ---
 
-#### **Command 0x03: Force Wipe**
+### **Command 0x03: Force Wipe**
 
 **Purpose:** Commands the adapter to run the sonde’s mechanical wiper (if available).  
 **Structure:**  
@@ -176,7 +176,7 @@ To set a 10-minute (600-second) transmit period:
 
 ---
 
-#### **Command 0x04: Change Parameter Types**
+### **Command 0x04: Change Parameter Types**
 
 **Purpose:** Dynamically reconfigures which sonde parameters the adapter provides.  
 **Structure:**  
@@ -202,7 +202,7 @@ Send:
 
 ---
 
-#### **Command 0x05: Force Mkrwan 1310 reboot**
+### **Command 0x05: Force Mkrwan 1310 reboot**
 **Purpose:** Reboot the arduino Mkrwan
 
 **Structure:**  
@@ -214,7 +214,7 @@ Send:
 **Details:**
 - Run with caution, rebooting the mkrwan causes it to disconnect from the network and retry the join request.
 
-#### Example Downlink Commands (Hex Format)
+### Example Downlink Commands (Hex Format)
 
 | Command Description                 | Command Code | Payload Example (Hex Bytes)                  | Notes |
 |------------------------------------|--------------|----------------------------------------------|-------|
@@ -226,7 +226,7 @@ Send:
 | **Force Mkrwan 1310 reboot** | `0x05`       | `05`                                         | Reboots the MKR WAN 1310 device. |
 | **Invalid Command**                | `0xFF`       | `FF`                                         | Handled as unknown command in firmware. |
 
-##### Format Breakdown
+#### Format Breakdown
 
 - First byte is always the **command code**:
   - `0x01`: Change transmit period
@@ -239,7 +239,7 @@ Send:
   - For `0x01`: 2 bytes (little endian) for new transmit interval.
   - For `0x04`: Up to 32 parameter codes (1 byte each, from 1 to 243).
 
-#####  Notes
+####  Notes
 
 - All values must be sent as **raw binary** hex bytes.
 - All numeric values are sent in **little-endian** format where applicable.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ The LoRaWAN payload will be divided into multiple packets, each conforming to th
 [N]   -> CRC8 byte
 ```
 
+### Date/Time
+
+The MKRWAN firmware extracts date and time from the EXO Sonde using Modbus registers **51** (date) and **54** (time). To ensure accurate timestamping, these registers must always remain enabled. During `setup()`, the MKRWAN automatically checks and enforces this requirement. If the EXO Sonde has already reached its maximum limit of **32 enabled parameters**, the MKRWAN will remove the last two parameters in the list to make room for the required date and time registers.
+
 ## Heartbeat Measurement
 
 A heartbeat signal will always be transmitted and **cannot be disabled**, even when no data is being collected from the EXO Sonde. This signal is a 1-byte value that starts at 1 and increments to 255, then wraps back to 1. The heartbeat is a custom parameter specifically designed to monitor the EXO Sonde to LoRaWAN Bridge. It is not part of Xylem’s official EXO Sonde documentation.

--- a/README.md
+++ b/README.md
@@ -202,6 +202,18 @@ Send:
 
 ---
 
+#### **Command 0x05: Force Mkrwan 1310 reboot**
+**Purpose:** Reboot the arduino Mkrwan
+
+**Structure:**  
+```
+[0x05]
+```
+**Length:** 1 byte 
+
+**Details:**
+- Run with caution, rebooting the mkrwan causes it to disconnect from the network and retry the join request.
+
 #### Example Downlink Commands (Hex Format)
 
 | Command Description                 | Command Code | Payload Example (Hex Bytes)                  | Notes |
@@ -211,6 +223,7 @@ Send:
 | **Force Wipe**                     | `0x03`       | `03`                                         | Initiates a wiper clean cycle on the sensor. |
 | **Change Parameter Types** (1 param) | `0x04`     | `04 18`                                      | Sets param list to only **pH (code 18)**. |
 | **Change Parameter Types** (multi) | `0x04`       | `04 18 212 223 243` → `04 12 D5 DF F3`       | pH (18), ODO mg/L (212), Turbidity FNU (223), NitraLED mg/L (243) – converted to 1-byte hex codes: `12 D4 DF F3`. |
+| **Force Mkrwan 1310 reboot** | `0x05`       | `05`                                         | Reboots the MKR WAN 1310 device. |
 | **Invalid Command**                | `0xFF`       | `FF`                                         | Handled as unknown command in firmware. |
 
 ##### Format Breakdown
@@ -220,6 +233,7 @@ Send:
   - `0x02`: Force sample
   - `0x03`: Force wipe
   - `0x04`: Change parameter types
+  - `0x05`: Force reboot
 
 - Payloads after the command code vary:
   - For `0x01`: 2 bytes (little endian) for new transmit interval.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,22 @@ A heartbeat signal will always be transmitted and **cannot be disabled**, even w
 
 > **Note:** If the heartbeat resets to 1 before reaching 255, this indicates that the MKR WAN 1310 has been restarted.
 
+## LED Status
+
+The MKRWAN 1310 uses the built-in LED (pin 6) to indicate system status:
+
+| State                        | Pattern Description           | Function                  |
+| ---------------------------- | ----------------------------- | ------------------------- |
+| **Join Success**             | 5 fast flashes                | `blinkJoinPassed()`           |
+| **Join Failure**             | 3 long flashes with pause     | `blinkJoinFailed()`           |
+| **Sensor Read Success**      | 2 short flashes               | `blinkSensorReadPassed()` |
+| **Sensor Read Failure**      | 2 medium flashes              | `blinkSensorReadFailed()` |
+| **LoRaWAN TX Success**       | 3 fast flashes                | `blinkTxPassed()`         |
+| **LoRaWAN TX Failure**       | 4 slow flashes                | `blinkTxFailed()`         |
+| **Waiting** | 1 brief flash | `blinkWaiting()`          |
+
+All functions are defined in `main.ino`.
+
 ## Downlink Command Structure
 
 The device supports several LoRaWAN downlink commands for remote configuration and control. Downlink messages follow a simple command-based structure, where the **first byte indicates the command type**, and the **subsequent bytes contain any associated parameters**.

--- a/main/main.ino
+++ b/main/main.ino
@@ -475,10 +475,12 @@ void EnableDateTimeRegister() {
     bool hasTime = false;
 
     // Step 1: Read current param codes
+    dbg_print("[EXO] Currently enabled Parameters: ");
     for (int i = 0; i < MAX_PARAM_CODES; i++) {
         currentCodes[i] = modbus.uint16FromRegister(0x03, MIN_PARAM_TYPE_REGISTER + i);
         dbg_print(currentCodes[i]); dbg_print(",");
     }
+    dbg_println(" ")
 
     // Step 2: Filter out 52-53 and keep 51, track 51 and 54
     for (int i = 0; i < MAX_PARAM_CODES; i++) {
@@ -497,7 +499,7 @@ void EnableDateTimeRegister() {
     if (!hasTime) requiredSpace++;
 
     if (filteredCount + requiredSpace > MAX_PARAM_CODES) {
-        dbg_println("[EXO] Full param list. Dropping last parameters to make room for 51 and 54...");
+        dbg_println("[EXO] Parameter space is full. Dropping last parameters to make room for 51 and 54...");
         filteredCount = MAX_PARAM_CODES - requiredSpace;
     }
 
@@ -510,6 +512,7 @@ void EnableDateTimeRegister() {
     }
 
     // Step 5: Write updated param codes back to adapter
+    dbg_println("[EXO] Adding Date and Time registers to enabled parameters...");
     changeParamType(filteredCount, filteredCodes);
 }
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -472,7 +472,7 @@ void EnableDateTimeRegister() {
         if (verbose) { dbg_print(currentCodes[i]); dbg_print(",");}
     }
 
-    // Step 2: Filter out 52 and 53, keep others, and track 51 and 54
+    // Step 2: Filter out 52-53 and keep 51, track 51 and 54
     for (int i = 0; i < MAX_PARAM_CODES; i++) {
         pingWatchdog("EnableDateRegister() filtering codes");
         uint16_t code = currentCodes[i];
@@ -485,8 +485,8 @@ void EnableDateTimeRegister() {
     }
 
     // Step 3: Ensure 51 and 54 are added if missing
-    if (!has51) filteredCodes[filteredCount++] = 51;
-    if (!has54) filteredCodes[filteredCount++] = 54;
+    if (!hasDate) filteredCodes[filteredCount++] = DATE_REGISTER;
+    if (!hasTime) filteredCodes[filteredCount++] = TIME_REGISTER;
 
     // Step 4: Write updated param codes to adapter
     changeParamType(filteredCount, filteredCodes);

--- a/main/main.ino
+++ b/main/main.ino
@@ -847,7 +847,10 @@ void BuildAndSendLoRaPackets(uint16_t sample_period, uint16_t* codes, uint16_t* 
             dbg_print("0 (sample_period), ");
         }
 
-        if (index + 4 >= MAX_PAYLOAD_SIZE) continue; // avoid overload
+        if (index + 4 >= MAX_PAYLOAD_SIZE) { // avoid overload
+            dbg_println("[LORA] ERROR: Not enough space for more parameters in payload, skipping packet.");
+            continue;
+        }  
 
         while (remainingParams > 0 && i < numParams) {
             if (codes[i] != 0 && codes[i] != DATE_REGISTER  &&  codes[i] != TIME_REGISTER) {

--- a/main/main.ino
+++ b/main/main.ino
@@ -539,6 +539,11 @@ void HandleDownlinkCommand() {
                 changeParamType(Params, rcv);
             }
             break;
+        case 0x05: // Force a mkrwan reboot
+            dbg_println("[LORA] Force Reboot triggered");
+            dbg_println("[LORA] Rebooting the MKR WAN 1310...");
+            while(1){}
+            break;
         default:
             dbg_print("[LORA] Error: Unknown command code 0x");
             dbg_printhexln(command);

--- a/main/main.ino
+++ b/main/main.ino
@@ -480,7 +480,7 @@ void EnableDateTimeRegister() {
         currentCodes[i] = modbus.uint16FromRegister(0x03, MIN_PARAM_TYPE_REGISTER + i);
         dbg_print(currentCodes[i]); dbg_print(",");
     }
-    dbg_println(" ")
+    dbg_println(" ");
 
     // Step 2: Filter out 52-53 and keep 51, track 51 and 54
     for (int i = 0; i < MAX_PARAM_CODES; i++) {

--- a/main/main.ino
+++ b/main/main.ino
@@ -106,6 +106,7 @@ void saveConfig() {
     if (current.txPeriod != TRANSMIT_PERIOD) {
         config_store.write({TRANSMIT_PERIOD});
         dbg_println("Done.");
+        dbg_print("- TRANSMIT_PERIOD: "); dbg_println(TRANSMIT_PERIOD);
     } else {
         dbg_println("No changes.");
     }
@@ -121,6 +122,8 @@ void loadConfig() {
     PersistentConfig config = config_store.read();
     TRANSMIT_PERIOD = (config.txPeriod >= 60 && config.txPeriod <= 7200) ? config.txPeriod : DEFAULT_TRANSMIT_PERIOD;
     ADAPTER_PERIOD = TRANSMIT_PERIOD / 2;
+    dbg_println("Done.");
+    dbg_print("- TRANSMIT_PERIOD: "); dbg_println(TRANSMIT_PERIOD);
 }
 
 /* -------------------------------------------------------------------------------------

--- a/main/main.ino
+++ b/main/main.ino
@@ -467,14 +467,14 @@ void EnableDateTimeRegister() {
 
     // Step 1: Read current param codes
     for (int i = 0; i < MAX_PARAM_CODES; i++) {
-        pingWatchdog("EnableDateRegister() reading codes");
+        pingWatchdog("EnableDateTimeRegister() reading codes");
         currentCodes[i] = modbus.uint16FromRegister(0x03, MIN_PARAM_TYPE_REGISTER + i);
         if (verbose) { dbg_print(currentCodes[i]); dbg_print(",");}
     }
 
     // Step 2: Filter out 52-53 and keep 51, track 51 and 54
     for (int i = 0; i < MAX_PARAM_CODES; i++) {
-        pingWatchdog("EnableDateRegister() filtering codes");
+        pingWatchdog("EnableDateTimeRegister() filtering codes");
         uint16_t code = currentCodes[i];
         if (code == 0 || code == 52 || code == 53) continue;
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -77,7 +77,8 @@ const int MAX_paramsPerPacket = (MAX_PAYLOAD_SIZE - METADATA_BYTES) / PARAM_BYTE
 // max waiting time (milliseconds) for joining
 const int JOIN_TIMEOUT = 90000; 
 // Default lorawan transmit period (seconds), min = 60 sec, max = 7200 sec
-uint16_t TRANSMIT_PERIOD = 300;
+const uint16_t DEFAULT_TRANSMIT_PERIOD = 300;
+uint16_t TRANSMIT_PERIOD = DEFAULT_TRANSMIT_PERIOD;
 // Default adapter sample period (seconds), min = 15 sec, max = 3600 sec
 uint16_t ADAPTER_PERIOD = TRANSMIT_PERIOD / 2;
 // Force Sample flag
@@ -112,11 +113,13 @@ void saveConfig() {
 
 void loadConfig() {
     /*-------------------------------------------------------------------------------------------------------
-    Load the configuration from persistent storage
+    Load the configuration from persistent storage.
+    This function reads the configuration and sets the transmit period and adapter period accordingly.
+    If the stored value is out of bounds, it uses the default TRANSMIT_PERIOD.
     --------------------------------------------------------------------------------------------------------*/
     dbg_print("[CONFIG] Loading configuration... ");
     PersistentConfig config = config_store.read();
-    TRANSMIT_PERIOD = (config.txPeriod >= 60 && config.txPeriod <= 7200) ? config.txPeriod : 300;
+    TRANSMIT_PERIOD = (config.txPeriod >= 60 && config.txPeriod <= 7200) ? config.txPeriod : DEFAULT_TRANSMIT_PERIOD;
     ADAPTER_PERIOD = TRANSMIT_PERIOD / 2;
 }
 

--- a/main/main.ino
+++ b/main/main.ino
@@ -478,7 +478,7 @@ void EnableDateTimeRegister() {
     for (int i = 0; i < MAX_PARAM_CODES; i++) {
         pingWatchdog("EnableDateTimeRegister() reading codes");
         currentCodes[i] = modbus.uint16FromRegister(0x03, MIN_PARAM_TYPE_REGISTER + i);
-        if (verbose) { dbg_print(currentCodes[i]); dbg_print(",");}
+        dbg_print(currentCodes[i]); dbg_print(",");
     }
 
     // Step 2: Filter out 52-53 and keep 51, track 51 and 54

--- a/main/main.ino
+++ b/main/main.ino
@@ -96,6 +96,10 @@ typedef struct {
 FlashStorage(config_store, PersistentConfig);
 
 void saveConfig() {
+    /*-------------------------------------------------------------------------------------------------------
+    Save the current configuration to persistent storage
+    This function checks if the values have changed before writing to avoid unnecessary writes.
+    -------------------------------------------------------------------------------------------------------*/
     dbg_print("[CONFIG] Saving configuration... ");
     PersistentConfig current = config_store.read();
     if (current.txPeriod != TRANSMIT_PERIOD) {
@@ -107,6 +111,9 @@ void saveConfig() {
 }
 
 void loadConfig() {
+    /*-------------------------------------------------------------------------------------------------------
+    Load the configuration from persistent storage
+    --------------------------------------------------------------------------------------------------------*/
     dbg_print("[CONFIG] Loading configuration... ");
     PersistentConfig config = config_store.read();
     TRANSMIT_PERIOD = (config.txPeriod >= 60 && config.txPeriod <= 7200) ? config.txPeriod : 300;
@@ -117,67 +124,88 @@ void loadConfig() {
 LED FUNCTIONS
 ---------------------------------------------------------------------------------------*/
 void blinkJoinPassed() {
-  int blinkDelay = 100;
-  for (int i = 0; i < 5; i++) {
+    /*-------------------------------------------------------------------------------------------------------
+    Blink the built-in LED to indicate a successful join to the LoRaWAN network
+    --------------------------------------------------------------------------------------------------------*/
+    int blinkDelay = 100;
+    for (int i = 0; i < 5; i++) {
     digitalWrite(LED_BUILTIN, HIGH);
     mydelay(blinkDelay);
     digitalWrite(LED_BUILTIN, LOW);
     mydelay(blinkDelay);
-  }
+    }
 }
 
 void blinkJoinFailed() {
-  int blinkDelay = 300;
-  for (int i = 0; i < 3; i++) {
+    /*-------------------------------------------------------------------------------------------------------
+    Blink the built-in LED to indicate a failed join to the LoRaWAN network
+    --------------------------------------------------------------------------------------------------------*/
+    int blinkDelay = 300;
+    for (int i = 0; i < 3; i++) {
     digitalWrite(LED_BUILTIN, HIGH);
     mydelay(blinkDelay);
     digitalWrite(LED_BUILTIN, LOW);
     mydelay(blinkDelay);
-  }
-  mydelay(1000);
+    }
+    mydelay(1000);
 }
 
 void blinkSensorReadPassed() {
-  digitalWrite(LED_BUILTIN, HIGH);
-  mydelay(50);
-  digitalWrite(LED_BUILTIN, LOW);
-  mydelay(150);
-  digitalWrite(LED_BUILTIN, HIGH);
-  mydelay(50);
-  digitalWrite(LED_BUILTIN, LOW);
+    /*-------------------------------------------------------------------------------------------------------
+    Blink the built-in LED to indicate a successful sensor read
+    --------------------------------------------------------------------------------------------------------*/
+    digitalWrite(LED_BUILTIN, HIGH);
+    mydelay(50);
+    digitalWrite(LED_BUILTIN, LOW);
+    mydelay(150);
+    digitalWrite(LED_BUILTIN, HIGH);
+    mydelay(50);
+    digitalWrite(LED_BUILTIN, LOW);
 }
 
 void blinkSensorReadFailed() {
-  for (int i = 0; i < 2; i++) {
+    /*-------------------------------------------------------------------------------------------------------
+    Blink the built-in LED to indicate a failed sensor read
+    --------------------------------------------------------------------------------------------------------*/
+    for (int i = 0; i < 2; i++) {
     digitalWrite(LED_BUILTIN, HIGH);
     mydelay(250);
     digitalWrite(LED_BUILTIN, LOW);
     mydelay(100);
-  }
+    }
 }
 
 void blinkTxPassed() {
-  for (int i = 0; i < 3; i++) {
+    /*-------------------------------------------------------------------------------------------------------
+    Blink the built-in LED to indicate a successful transmission of a LoRaWAN packet
+    --------------------------------------------------------------------------------------------------------*/
+    for (int i = 0; i < 3; i++) {
     digitalWrite(LED_BUILTIN, HIGH);
     mydelay(80);
     digitalWrite(LED_BUILTIN, LOW);
     mydelay(80);
-  }
+    }
 }
 
 void blinkTxFailed() {
-  for (int i = 0; i < 4; i++) {
+    /*-------------------------------------------------------------------------------------------------------
+    Blink the built-in LED to indicate a failed transmission of a LoRaWAN packet
+    --------------------------------------------------------------------------------------------------------*/
+    for (int i = 0; i < 4; i++) {
     digitalWrite(LED_BUILTIN, HIGH);
     mydelay(100);
     digitalWrite(LED_BUILTIN, LOW);
     mydelay(300);
-  }
+    }
 }
 
 void blinkWaiting() {
-  digitalWrite(LED_BUILTIN, HIGH);
-  mydelay(200);
-  digitalWrite(LED_BUILTIN, LOW);
+    /*-------------------------------------------------------------------------------------------------------
+    Blink the built-in LED to indicate waiting for an operation to complete
+    --------------------------------------------------------------------------------------------------------*/
+    digitalWrite(LED_BUILTIN, HIGH);
+    mydelay(200);
+    digitalWrite(LED_BUILTIN, LOW);
 }
 
 /* -------------------------------------------------------------------------------------

--- a/main/main.ino
+++ b/main/main.ino
@@ -493,11 +493,25 @@ void EnableDateTimeRegister() {
         filteredCodes[filteredCount++] = code;
     }
 
-    // Step 3: Ensure 51 and 54 are added if missing
-    if (!hasDate) filteredCodes[filteredCount++] = DATE_REGISTER;
-    if (!hasTime) filteredCodes[filteredCount++] = TIME_REGISTER;
+    // Step 3: If already full (>= 32 after filtering), make room for 51 and 54
+    int requiredSpace = 0;
+    if (!hasDate) requiredSpace++;
+    if (!hasTime) requiredSpace++;
 
-    // Step 4: Write updated param codes to adapter
+    if (filteredCount + requiredSpace > MAX_PARAM_CODES) {
+        dbg_println("[EXO] Full param list. Dropping last parameters to make room for 51 and 54...");
+        filteredCount = MAX_PARAM_CODES - requiredSpace;
+    }
+
+    // Step 4: Ensure 51 and 54 are present
+    if (!hasDate && filteredCount < MAX_PARAM_CODES) {
+        filteredCodes[filteredCount++] = DATE_REGISTER;
+    }
+    if (!hasTime && filteredCount < MAX_PARAM_CODES) {
+        filteredCodes[filteredCount++] = TIME_REGISTER;
+    }
+
+    // Step 5: Write updated param codes back to adapter
     changeParamType(filteredCount, filteredCodes);
 }
 
@@ -915,6 +929,7 @@ void setup() {
         dbg_println("[MKRWAN] Failed to join LoRaWAN network. Rebooting...");
         while(1){}
     }
+    pingWatchdog("setup() end");
 }
 
 void loop() {

--- a/main/main.ino
+++ b/main/main.ino
@@ -466,8 +466,10 @@ bool SendPacket(uint8_t* payload, int numBytes, int maxRetries = 5, int retryDel
             break;
         } else {
             dbg_print("x ");    
-            if (attempt < maxRetries) 
+            if (attempt < maxRetries) {
+                blinkWaiting();
                 mydelay(retryDelay * attempt);  // exponential backoff 
+            }
         }
     }
     if (!success){

--- a/main/main.ino
+++ b/main/main.ino
@@ -30,7 +30,7 @@ const bool verbose = false; // set to true to enable verbose output
 EXOSONDE DEVICE GLOBAL VARIABLES
 ---------------------------------------------------------------------------------------*/
 uint8_t devID = 0x12;   // Sonde device ID
-uint8_t version = 0x02; // Sonde Hardware/Software version
+uint8_t version = 0x03; // Sonde Hardware/Software version
 
 // Bus configuration
 byte modbusAddress = 0x01;


### PR DESCRIPTION
This pull request updates adds new features, improves clarity, and expands documentation on system functionality. The most significant changes introduce details about date/time handling, LED status indicators, watchdog, and a new downlink command for rebooting the MKR WAN 1310 device.

### New Features and Functionality:

* **Date/Time Handling**: Added a section explaining how the MKRWAN firmware extracts date and time from Modbus registers and enforces their enablement during `setup()`. If the maximum limit of enabled parameters is reached, the firmware adjusts the configuration to accommodate these registers.

* **LED Status Indicators**: Introduced a table describing the built-in LED patterns on the MKRWAN 1310 for various system states, such as join success, sensor read success/failure, and LoRaWAN transmission success/failure. Corresponding function names for each pattern are also provided.

* **New Downlink Command**: Added documentation for a new downlink command (`0x05`) that reboots the MKR WAN 1310 device. This command is noted to disconnect the device from the network temporarily. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L205-R237) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R246-R262)

* **Watchdog**: Added a watchdog to restart the mkrwan 1310 if it gets stuck.

>NOTE: in the firmware version number was upped to three